### PR TITLE
fix permissions after creating postgresql data direcory

### DIFF
--- a/install
+++ b/install
@@ -10,6 +10,7 @@ if [[ ! -d "$DOKKU_ROOT/.postgresql" ]]; then
   mkdir -p "$DOKKU_ROOT/.postgresql"
   mkdir -p "$DOKKU_ROOT/.postgresql/data"
   docker run "$db_image" tar -cvps -C /var/lib/postgresql/9.1/main ./ | tar -xv -C "$DOKKU_ROOT/.postgresql/data/" -f -
+  docker run "$db_image" chown -R postgres:postgres /var/lib/postgresql/9.1/main
 
   if [[ ! -f "$DOKKU_ROOT/.postgresql/admin_pw" ]]; then
     admin_pass=$(openssl rand -base64 32|base64)


### PR DESCRIPTION
i had an error when installing plugin related to permissions, this sets the permissions to the docker postgres user's id:gid.  i'm not sure if this is the best fix, as (at least on my system) the docker postgres uid matches up with 'syslog' and 'fuse' group.

```
+ chown dokku: /home/dokku/.postgresql
+ chown dokku: /home/dokku/.postgresql/admin_pw
+ docker run -v /home/dokku/.postgresql/data:/var/lib/postgresql/9.1/main jeffutter/postgresql su postgres -c '/usr/lib/postgresql/9.1/bin/postgres --single -D /var/lib/postgresql/9.1/main -c config_file=/etc/postgresql/9.1/main/postgresql.conf <<< "CREATE USER root WITH SUPERUSER PASSWORD '\''sUpErSeCrEt'\'';"'
2013-12-27 03:09:51 UTC FATAL:  could not open file "/var/lib/postgresql/9.1/main/PG_VERSION": Permission denied
```
